### PR TITLE
Exception handlers & Modifiable timeout

### DIFF
--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetClient.java
@@ -35,6 +35,7 @@ public class RakNetClient extends RakNet {
 
     public RakNetClient(InetSocketAddress bindAddress, EventLoopGroup eventLoopGroup) {
         super(bindAddress, eventLoopGroup);
+        exceptionHandlers.add((t) -> log.error("An exception occurred in RakNet (Client)", t));
     }
 
     @Override
@@ -181,7 +182,6 @@ public class RakNetClient extends RakNet {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            log.error("An exception occurred in RakNet", cause);
             for (Consumer<Throwable> handler : RakNetClient.this.exceptionHandlers) {
                 handler.accept(cause);
             }

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetServer.java
@@ -49,6 +49,7 @@ public class RakNetServer extends RakNet {
     public RakNetServer(InetSocketAddress bindAddress, int bindThreads, EventLoopGroup eventLoopGroup) {
         super(bindAddress, eventLoopGroup);
         this.bindThreads = bindThreads;
+        exceptionHandler.add((t) -> log.error("An exception occurred in RakNet (Server)", t));
     }
 
     @Override
@@ -312,7 +313,7 @@ public class RakNetServer extends RakNet {
 
         @Override
         public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-            log.error("An exception occurred in RakNet", cause);
+
             for (Consumer<Throwable> exceptionHandler : RakNetServer.this.exceptionHandler) {
                 exceptionHandler.accept(cause);
             }

--- a/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
+++ b/raknet/src/main/java/com/nukkitx/network/raknet/RakNetSession.java
@@ -92,6 +92,7 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
     private Queue<IntRange> outgoingNaks;
     private volatile int unackedBytes;
     private volatile long lastMinWeight;
+    private int sessionTimeout = SESSION_TIMEOUT_MS;
 
     RakNetSession(InetSocketAddress address, Channel channel, int mtu, int protocolVersion, EventLoop eventLoop) {
         this.address = address;
@@ -819,6 +820,15 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
         this.channel.writeAndFlush(new DatagramPacket(buffer, this.address), this.voidPromise);
     }
 
+    public int getSessionTimeout(){
+        return sessionTimeout;
+    }
+
+    /** timeout in ms ( 1 second = 1000 ) **/
+    public void setSessionTimeout(int timeout){
+        this.sessionTimeout = timeout;
+    }
+
     /*
         Packet Handlers
      */
@@ -917,7 +927,7 @@ public abstract class RakNetSession implements SessionConnection<ByteBuf> {
     }
 
     public boolean isTimedOut(long curTime) {
-        return curTime - this.lastTouched >= SESSION_TIMEOUT_MS;
+        return curTime - this.lastTouched >= this.sessionTimeout;
     }
 
     public boolean isTimedOut() {


### PR DESCRIPTION
This PR implements two enhancements for the current Network library:
  - Developers are now able to assign exception handlers as Consumer<Throwable> to RakNetClients and RakNetServers. They are
    called whenever an exception occurs in the pipeline.

  - Developers are able to set the timeout of a RakNetSession, which is SESSION_TIMEOUT_MS by default. 

