### PR TITLE
Report host acceptance independently of health in NXS heartbeats

### DIFF
--- a/docs/external-signalling/README.md
+++ b/docs/external-signalling/README.md
@@ -51,6 +51,8 @@ The reply returns the accepted profile revision, readiness, lease/schedule,
 provider state and any admission-key updates. A host becomes routable only with
 a live lease, usable profile and acknowledged installed key.
 
+Report `healthy` and `acceptingPlayers` independently on every heartbeat. A healthy draining host reports false acceptance and continues reporting its actual remaining players. A serving host can pause and resume acceptance without changing lifecycle.
+
 Apply provider state before acknowledging its revision. `draining` stops new
 joins and preserves existing sessions; `closed` closes the transport. Provider
 routing and credential decisions take effect independently of host check-in.

--- a/docs/external-signalling/fixtures.mjs
+++ b/docs/external-signalling/fixtures.mjs
@@ -92,3 +92,6 @@ assert(f.fleetExamples.heartbeat.playerCount.sampledAt <= f.fleetExamples.heartb
 assert.deepEqual(Object.keys(f.fleetExamples.heartbeat.serverStatus).sort(),
     ['name', 'protocol', 'version', 'level', 'players', 'maxPlayers', 'gameType'].sort());
 console.log('NXS canonical signing, stateless encryption, fleet examples, and fixture hashes verified.');
+
+assert(schema.$defs.heartbeat.required.includes('acceptingPlayers'));
+assert.equal(f.fleetExamples.heartbeat.acceptingPlayers, true);

--- a/docs/external-signalling/nxs-v1.fixtures.json
+++ b/docs/external-signalling/nxs-v1.fixtures.json
@@ -118,7 +118,8 @@
         "gameType": 0,
         "protocol": 1234,
         "level": "world"
-      }
+      },
+      "acceptingPlayers": true
     }
   }
 }

--- a/docs/external-signalling/nxs-v1.schema.json
+++ b/docs/external-signalling/nxs-v1.schema.json
@@ -528,6 +528,7 @@
       "type": "object",
       "required": [
         "healthy",
+        "acceptingPlayers",
         "capacity",
         "load",
         "protocolVersion",
@@ -613,8 +614,33 @@
         },
         "playerCount": {
           "$ref": "#/$defs/playerCount"
+        },
+        "acceptingPlayers": {
+          "type": "boolean",
+          "description": "Explicit application willingness to accept new players, independent of health and sampled counts. Must be false while draining or closed."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "state": {
+                "enum": [
+                  "draining",
+                  "closed"
+                ]
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "acceptingPlayers": {
+                "const": false
+              }
+            }
+          }
+        }
+      ]
     },
     "checkIn": {
       "type": "object",

--- a/docs/external-signalling/wire-reference.md
+++ b/docs/external-signalling/wire-reference.md
@@ -215,11 +215,12 @@ endpoint alongside the runtime.
 
 ## `heartbeat`
 
-Required fields: `healthy,capacity,load,protocolVersion,clockUnixMillis,
+Required fields: `healthy,acceptingPlayers,capacity,load,protocolVersion,clockUnixMillis,
 checkInVersion,state,appliedStateRevision,gameOutcomes`.
 Optional fields: `build,region,serverStatus,hostProfile,hostProfileRevision,
 installedKeyIds,keyRequestId,extensions`.
 
+- `healthy` is application health. `acceptingPlayers` is explicit willingness to accept new players; false while draining or closed. A serving host may pause acceptance and later report true without changing lifecycle. Neither field is derived from player counts. Report acceptance changes promptly.
 - `capacity` is an integer from 0 to 1000000; `load` is a finite number from 0 to 1.
 - `state` is `serving`, `draining` or `closed`. A draining endpoint cannot resume
   serving in the same generation; a fresh endpoint requires recovery/completion.

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/ProviderClient.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/ProviderClient.java
@@ -123,7 +123,8 @@ public final class ProviderClient implements AutoCloseable {
         }
     }
 
-    private static final Gson JSON = new GsonBuilder().disableHtmlEscaping().create();
+    // Null is meaningful inside opaque extension data (for example, clearing a setting).
+    private static final Gson JSON = new GsonBuilder().disableHtmlEscaping().serializeNulls().create();
     private final Configuration config;
     private final ProviderStateStore store;
     private final ProviderTransport transport;
@@ -644,7 +645,7 @@ public final class ProviderClient implements AutoCloseable {
                 body.add("playerCount", JSON.toJsonTree(health.playerCount()));
             }
             body.addProperty("protocolVersion", health.protocolVersion());
-            body.addProperty("build", health.build());
+            if (health.build() != null) body.addProperty("build", health.build());
             if (config.region() != null) {
                 body.addProperty("region", config.region());
             }

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/ProviderClient.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/ProviderClient.java
@@ -93,7 +93,7 @@ public final class ProviderClient implements AutoCloseable {
     /**
      * Capacity and playerCount describe the same observation. Public server status is independent.
      */
-    public record Health(boolean healthy, int capacity, double load, String protocolVersion, String build,
+    public record Health(boolean healthy, boolean acceptingPlayers, int capacity, double load, String protocolVersion, String build,
                          PlayerCount playerCount) {
         public Health {
             if (capacity < 0 || capacity > 1000000 || !Double.isFinite(load) || load < 0 || load > 1
@@ -105,8 +105,8 @@ public final class ProviderClient implements AutoCloseable {
         /**
          * Hosts without actual player telemetry report unknown, never a synthetic zero.
          */
-        public Health(boolean healthy, int capacity, double load, String protocolVersion, String build) {
-            this(healthy, capacity, load, protocolVersion, build, null);
+        public Health(boolean healthy, boolean acceptingPlayers, int capacity, double load, String protocolVersion, String build) {
+            this(healthy, acceptingPlayers, capacity, load, protocolVersion, build, null);
         }
     }
 
@@ -143,6 +143,7 @@ public final class ProviderClient implements AutoCloseable {
     private final AtomicBoolean refreshQueued = new AtomicBoolean();
     private JsonObject state, discovery;
     private JsonObject registrationExtensions = new JsonObject();
+    private JsonObject heartbeatExtensions = new JsonObject();
     private PrivateKey privateKey;
     private String profileRevision;
     private JsonObject lastProfile;
@@ -595,6 +596,7 @@ public final class ProviderClient implements AutoCloseable {
         Health health = healthSupplier.get();
         return !Objects.equals(status, lastReportedStatus) || lastReportedHealth == null
                 || health.healthy() != lastReportedHealth.healthy()
+                || health.acceptingPlayers() != lastReportedHealth.acceptingPlayers()
                 || health.capacity() != lastReportedHealth.capacity()
                 || !Objects.equals(connectedPlayers(health), connectedPlayers(lastReportedHealth))
                 || !Objects.equals(health.protocolVersion(), lastReportedHealth.protocolVersion()) || !Objects.equals(
@@ -633,7 +635,9 @@ public final class ProviderClient implements AutoCloseable {
                 body.add("keyRequestId", state.get("keyRequestId"));
             }
             Health health = healthSupplier.get();
-            body.addProperty("healthy", health.healthy() && installedKeyId != null && hostState.equals("serving"));
+            body.addProperty("healthy", health.healthy());
+            body.addProperty("acceptingPlayers", health.acceptingPlayers() && installedKeyId != null && hostState.equals("serving"));
+            if (!heartbeatExtensions.isEmpty()) body.add("extensions", heartbeatExtensions.deepCopy());
             body.addProperty("capacity", health.capacity());
             body.addProperty("load", health.load());
             if (health.playerCount() != null) {
@@ -734,6 +738,11 @@ public final class ProviderClient implements AutoCloseable {
             if (revision < appliedStateRevision || !Set.of("serving", "draining", "closed").contains(target)) {
                 throw new IOException("Unsupported provider state");
             }
+            if (revision > appliedStateRevision && target.equals("serving") && !hostState.equals("serving")) {
+                // This endpoint's drain is permanent. Recovery with a fresh endpoint must apply resume.
+                diagnostics.accept("provider_resume_requires_recovery");
+                return;
+            }
             if (revision > appliedStateRevision) {
                 ProviderTransport.ApplyResult applied = target.equals("serving") ? ProviderTransport.ApplyResult.APPLIED
                         : transport.applyState(target).toCompletableFuture().get(10, TimeUnit.SECONDS);
@@ -807,8 +816,21 @@ public final class ProviderClient implements AutoCloseable {
     }
 
     /**
-     * Opaque optional extension metadata; the application decides what it means.
+     * Replace optional application observations and promptly send them when running.
+     * An omitted extension is not an application-level instruction to clear an earlier observation.
      */
+    public CompletableFuture<Void> updateHeartbeatExtensions(JsonObject extensions) {
+        JsonObject document = new JsonObject();
+        document.add("extensions", extensions.deepCopy());
+        JsonObject validated = ProtocolExtensions.copy(document);
+        return submit(() -> {
+            heartbeatExtensions = validated;
+            if (started) heartbeat();
+            return null;
+        });
+    }
+
+    /** Opaque registration metadata; the application decides what it means. */
     public CompletableFuture<JsonObject> extensions() {
         return submit(() -> registrationExtensions.deepCopy());
     }
@@ -895,7 +917,6 @@ public final class ProviderClient implements AutoCloseable {
     public CompletableFuture<Void> drain() {
         return submit(() -> {
             drainAndReport();
-            started = false;
             return null;
         });
     }

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderBench.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderBench.java
@@ -89,7 +89,7 @@ public final class ProviderBench {
                 registrationMode, authorization, token, region, pool, tags);
         var client = new ProviderClient(config, new ProviderStateStore(state), transport,
                 () -> new ServerStatus("Java bench", 1234, "fixture-only", "Fixture", 2, 50, 0),
-                () -> new ProviderClient.Health(true, 100, 0.02, "nethernet", "java-conformance"), System.err::println);
+                () -> new ProviderClient.Health(true, true, 100, 0.02, "nethernet", "java-conformance"), System.err::println);
         try {
             JsonObject registration = client.start().get(30, TimeUnit.SECONDS);
             String extensionsFile = System.getProperty("providerExtensionsFile");

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
@@ -31,7 +31,7 @@ class ProviderClientTest {
                     ProviderClient client = new ProviderClient(config,
                             new ProviderStateStore(path.resolve(standalone ? "standalone" : "pool")),
                             new FakeTransport(), () -> null,
-                            () -> new ProviderClient.Health(true, 20, 0, "nethernet", "fixture"), message -> {
+                            () -> new ProviderClient.Health(true, true, 20, 0, "nethernet", "fixture"), message -> {
                     });
                     try {
                         JsonObject current = client.start().get(20, TimeUnit.SECONDS);
@@ -66,19 +66,32 @@ class ProviderClientTest {
                     new AtomicReference<>(new ProviderClient.PlayerCount(3, System.currentTimeMillis()));
             var transport = new FakeTransport();
             transport.stateless = true;
+            java.util.concurrent.atomic.AtomicBoolean accepting = new java.util.concurrent.atomic.AtomicBoolean(true);
             ProviderClient client = new ProviderClient(
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Counts"),
                     new ProviderStateStore(path), transport,
                     () -> new ServerStatus("Global listing", 1234, "fixture", "world", 25000, 30000, 0),
-                    () -> new ProviderClient.Health(true, 20, .9, "nethernet", "fixture", sample.get()), message -> {
+                    () -> new ProviderClient.Health(true, accepting.get(), 20, .9, "nethernet", "fixture", sample.get()), message -> {
             });
             try {
+                JsonObject extensions = com.google.gson.JsonParser.parseString("{\"org.example.location\":{\"version\":1,\"critical\":false,\"data\":{\"country\":\"NL\"}}}").getAsJsonObject();
+                client.updateHeartbeatExtensions(extensions).get(10, TimeUnit.SECONDS);
+                extensions.getAsJsonObject("org.example.location").getAsJsonObject("data").addProperty("country", "GB");
                 client.start().get(20, TimeUnit.SECONDS);
+                assertEquals("NL", stub.lastHeartbeat.getAsJsonObject("extensions").getAsJsonObject("org.example.location").getAsJsonObject("data").get("country").getAsString());
                 assertEquals(3, stub.lastHeartbeat.getAsJsonObject("playerCount").get("connectedPlayers").getAsInt());
                 assertEquals(sample.get().sampledAt(),
                         stub.lastHeartbeat.getAsJsonObject("playerCount").get("sampledAt").getAsLong());
                 assertEquals(20, stub.lastHeartbeat.get("capacity").getAsInt());
                 assertEquals(25000, stub.lastHeartbeat.getAsJsonObject("serverStatus").get("players").getAsInt());
+                assertTrue(stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
+                accepting.set(false);
+                client.requestStatusRefresh();
+                eventually(() -> !stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
+                assertTrue(stub.lastHeartbeat.get("healthy").getAsBoolean());
+                accepting.set(true);
+                client.requestStatusRefresh();
+                eventually(() -> stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
                 int before = stub.heartbeats;
                 sample.set(new ProviderClient.PlayerCount(3, System.currentTimeMillis()));
                 client.requestStatusRefresh();
@@ -89,11 +102,20 @@ class ProviderClientTest {
                 eventually(() -> stub.lastHeartbeat.getAsJsonObject("playerCount").get("connectedPlayers").getAsInt()
                         == 4);
                 assertEquals(25000, stub.lastHeartbeat.getAsJsonObject("serverStatus").get("players").getAsInt());
+                client.drain().get(10, TimeUnit.SECONDS);
+                assertFalse(stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
+                sample.set(new ProviderClient.PlayerCount(5, System.currentTimeMillis()));
+                client.requestStatusRefresh();
+                eventually(() -> stub.lastHeartbeat.getAsJsonObject("playerCount").get("connectedPlayers").getAsInt() == 5);
+                assertTrue(stub.lastHeartbeat.get("healthy").getAsBoolean());
+                assertFalse(stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
             } finally {
                 client.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
             }
             assertTrue(stub.draining);
-            assertEquals(4, stub.lastHeartbeat.getAsJsonObject("playerCount").get("connectedPlayers").getAsInt());
+            assertTrue(stub.lastHeartbeat.get("healthy").getAsBoolean());
+            assertFalse(stub.lastHeartbeat.get("acceptingPlayers").getAsBoolean());
+            assertEquals(5, stub.lastHeartbeat.getAsJsonObject("playerCount").get("connectedPlayers").getAsInt());
         }
     }
 
@@ -106,7 +128,7 @@ class ProviderClientTest {
                             "customers", Map.of("plan", "premium"));
             ProviderClient client =
                     new ProviderClient(config, new ProviderStateStore(path), new FakeTransport(), () -> null,
-                            () -> new ProviderClient.Health(true, 10, 0, "nethernet", "fixture"), message -> {
+                            () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", "fixture"), message -> {
                     });
             try {
                 JsonObject registration = client.start().get(20, TimeUnit.SECONDS);
@@ -131,7 +153,7 @@ class ProviderClientTest {
             ProviderClient client = new ProviderClient(
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example"),
                     new ProviderStateStore(path), new FakeTransport(), () -> null,
-                    () -> new ProviderClient.Health(true, 10, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 JsonObject result = client.start().get(20, TimeUnit.SECONDS);
@@ -161,7 +183,7 @@ class ProviderClientTest {
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Scheduled"),
                     new ProviderStateStore(path), transport,
                     () -> new ServerStatus("Scheduled", 1234, "fixture", "world", players.get(), 40, 0),
-                    () -> new ProviderClient.Health(true, 40, players.get() / 40.0, "nethernet", "fixture"),
+                    () -> new ProviderClient.Health(true, true, 40, players.get() / 40.0, "nethernet", "fixture"),
                     message -> {
                     });
             try {
@@ -203,7 +225,7 @@ class ProviderClientTest {
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Scheduled"),
                     new ProviderStateStore(path), replacement,
                     () -> new ServerStatus("Restarted", 1234, "fixture", "world", 0, 40, 0),
-                    () -> new ProviderClient.Health(true, 40, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 40, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 resumed.start().get(20, TimeUnit.SECONDS);
@@ -296,7 +318,7 @@ class ProviderClientTest {
             var config = new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example");
             ProviderClient client = new ProviderClient(config, new ProviderStateStore(path), host,
                     () -> new ServerStatus("Example", 1234, "preview-fixture", "", players.get(), 40, 0),
-                    () -> new ProviderClient.Health(true, 100, 0.1, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 100, 0.1, "nethernet", "fixture"), message -> {
             });
             JsonObject registration = client.start().get(20, TimeUnit.SECONDS);
             assertEquals("example-machine-1", registration.get("instanceId").getAsString());
@@ -317,7 +339,7 @@ class ProviderClientTest {
             FakeTransport restarted = new FakeTransport();
             ProviderClient resumed = new ProviderClient(config, new ProviderStateStore(path), restarted,
                     () -> new ServerStatus("Restarted", 1234, "preview-fixture", "", 1, 50, 1),
-                    () -> new ProviderClient.Health(true, 100, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 100, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 assertEquals("example-machine-1",
@@ -345,7 +367,7 @@ class ProviderClientTest {
             FakeTransport host = new FakeTransport();
             var config = new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example");
             var health =
-                    (Supplier<ProviderClient.Health>) () -> new ProviderClient.Health(true, 100, 0.1,
+                    (Supplier<ProviderClient.Health>) () -> new ProviderClient.Health(true, true, 100, 0.1,
                             "nethernet", "fixture");
             ProviderClient client = new ProviderClient(config, new ProviderStateStore(path), host, () -> {
                 if (players.get() < 0) {
@@ -389,7 +411,7 @@ class ProviderClientTest {
             var client = new ProviderClient(
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example"),
                     new ProviderStateStore(path), host, () -> null,
-                    () -> new ProviderClient.Health(true, 10, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 client.start().get(20, TimeUnit.SECONDS);
@@ -420,7 +442,7 @@ class ProviderClientTest {
             var client = new ProviderClient(
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example"),
                     new ProviderStateStore(path), host, () -> null,
-                    () -> new ProviderClient.Health(true, 10, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", "fixture"), message -> {
             });
             client.start().get(20, TimeUnit.SECONDS);
             Files.move(path.resolve("provider-state.json"), path.resolve("saved-state.json"));

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
@@ -29,7 +29,7 @@ class ProviderClientTest {
             FakeTransport refusing = new FakeTransport();
             refusing.refuseKeys = true;
             ProviderClient first = new ProviderClient(config, new ProviderStateStore(directory), refusing, () -> null,
-                    () -> new ProviderClient.Health(true, 20, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 20, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 assertThrows(Exception.class, () -> first.start().get(20, TimeUnit.SECONDS));
@@ -42,7 +42,7 @@ class ProviderClientTest {
             assertFalse(persisted.contains("\"ticketKeys\":[{"), "a refused admission key was persisted: " + persisted);
 
             ProviderClient second = new ProviderClient(config, new ProviderStateStore(directory), new FakeTransport(),
-                    () -> null, () -> new ProviderClient.Health(true, 20, 0, "nethernet", "fixture"), message -> {
+                    () -> null, () -> new ProviderClient.Health(true, true, 20, 0, "nethernet", "fixture"), message -> {
             });
             try {
                 assertNotNull(second.start().get(20, TimeUnit.SECONDS));

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderClientTest.java
@@ -153,10 +153,17 @@ class ProviderClientTest {
             ProviderClient client = new ProviderClient(
                     new ProviderClient.Configuration(URI.create(stub.origin), "nxs-admission-v1", "Example"),
                     new ProviderStateStore(path), new FakeTransport(), () -> null,
-                    () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", "fixture"), message -> {
+                    () -> new ProviderClient.Health(true, true, 10, 0, "nethernet", null), message -> {
             });
             try {
+                JsonObject extensions = JsonParser.parseString(
+                        "{\"org.example.location\":{\"version\":1,\"critical\":false,\"data\":{\"location\":null}}}")
+                        .getAsJsonObject();
+                client.updateHeartbeatExtensions(extensions).get(10, TimeUnit.SECONDS);
                 JsonObject result = client.start().get(20, TimeUnit.SECONDS);
+                assertEquals(extensions, stub.lastHeartbeat.getAsJsonObject("extensions"),
+                        "Explicit null in opaque extension data must survive wire serialization");
+                assertFalse(stub.lastHeartbeat.has("build"), "Unspecified optional health fields stay omitted");
                 assertFalse(result.has("ticketKey"));
                 assertEquals(stub.extensionMetadata, result.getAsJsonObject("extensions"));
                 assertFalse(Files.readString(path.resolve("provider-state.json"))

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderJourneysTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/ProviderJourneysTest.java
@@ -21,7 +21,7 @@ class ProviderJourneysTest {
                                          ProviderClientTest.FakeTransport transport) throws Exception {
         return new ProviderClient(configuration, new ProviderStateStore(directory), transport,
                 () -> new ServerStatus("Independent host", 1000, "conformance", "world", 1, 20, 0),
-                () -> new ProviderClient.Health(true, 100, .01, "nethernet", "fixture"), message -> {
+                () -> new ProviderClient.Health(true, true, 100, .01, "nethernet", "fixture"), message -> {
         });
     }
 

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/ProviderNativeBench.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/ProviderNativeBench.java
@@ -68,7 +68,7 @@ public final class ProviderNativeBench {
                     new ProviderClient.Configuration(origin, "nxs-admission-v1", "Provider native integration"),
                     new ProviderStateStore(state), nativeHost,
                     () -> new ServerStatus("Automatic native server", 1234, "fixture-only", "Integration", 0, 4, 0),
-                    () -> new ProviderClient.Health(true, 4, 0, "nethernet", "provider-native-bench"),
+                    () -> new ProviderClient.Health(true, true, 4, 0, "nethernet", "provider-native-bench"),
                     System.err::println);
             JsonObject registration = provider.start().get(45, TimeUnit.SECONDS);
             if (args.length > 4) {


### PR DESCRIPTION
Hosts report whether they accept new players independently of health and connected-player telemetry. A draining host keeps sending its actual connected-player count, and a transport that cannot resume no longer acknowledges a serving revision.

The heartbeat requires `acceptingPlayers` and permits optional application observations in the neutral extension envelope. Explicit JSON null values in opaque extension data survive serialization, allowing consumers to clear an observation; unspecified optional health fields remain omitted. Provider-specific location and routing policy stay outside this SDK.

Public status and routing telemetry remain separate:

- `serverStatus.players` / `serverStatus.maxPlayers` describe the advertised listing.
- `playerCount.connectedPlayers` / `playerCount.sampledAt` describe actual connections on this instance; heartbeat `capacity` describes that instance's capacity.
- The regression advertises 25,000/30,000 players while reporting 3/20 locally, then verifies count changes and draining do not replace the advertised total.

Validation on `f1711462f862f0ca43aa12c247a8723841084e7f`, refreshed against `nethernet` at `87edfb5e756ad0cf890421c448c2ae79553a6d5d`:

- 46 external-signalling and 51 NetherNet unit tests passed.
- Nine native admission tests passed using OpenCollab JNI `0.24.5.0-20260911.144749-4`.
- `node docs/external-signalling/fixtures.mjs` and `git diff --check` passed.
- Local validation resolves JUnit from Maven Central to avoid incomplete metadata in this machine's Maven-local cache.

The `Health` constructor now requires explicit acceptance; consumers must update with this change. The matching Geyser consumer is https://github.com/onebeastchris/Geyser/pull/18 (110 core tests and standalone build/startup checks passed against this exact Network source). This is an AI-assisted draft. Automated tests do not establish human-reviewed stock-client gameplay; that remains unverified for this refreshed head.
