### PR TITLE
Bind NXS admission to the signalling CPK at game login

### DIFF
--- a/docs/external-signalling/fixtures.mjs
+++ b/docs/external-signalling/fixtures.mjs
@@ -12,6 +12,7 @@ const digest = value => createHash('sha256').update(value).digest();
 const b64 = value => value.toString('base64url');
 const hmac = (key, data) => createHmac('sha256', key).update(data).digest();
 const update = process.argv.includes('--write');
+const updateAdmission = update || process.argv.includes('--write-admission');
 
 const f = read('nxs-v1.fixtures.json'), c = f.challenge;
 f.protocol = c.protocol = protocol;
@@ -43,12 +44,26 @@ for (const [name, payload] of [['proof', proof], ['request', request]]) {
 if (update) write('nxs-v1.fixtures.json', f);
 
 const v = read('stateless-admission-v1.fixtures.json'), claims = v.claims, context = v.context;
+const canonicalCpk = createPublicKey({key: v.identity.publicKeyJwk, format: 'jwk'}).export({type: 'spki', format: 'der'}).toString('base64');
+const bindingInput = Buffer.from(`nxs-identity-binding-v1\0${context.audience}\0${canonicalCpk}`, 'utf8');
+const fullBinding = hmac(Buffer.from(context.secret, 'utf8'), bindingInput);
+const identityBindingHex = fullBinding.subarray(0, 16).toString('hex');
+if (updateAdmission) {
+  v.identity.canonicalCpk = canonicalCpk;
+  v.identity.hmacInputHex = bindingInput.toString('hex');
+  v.identity.hmacSha256Hex = fullBinding.toString('hex');
+  claims.identityBindingHex = identityBindingHex;
+}
+assert.equal(v.identity.canonicalCpk, canonicalCpk);
+assert.equal(v.identity.hmacInputHex, bindingInput.toString('hex'));
+assert.equal(v.identity.hmacSha256Hex, fullBinding.toString('hex'));
+assert.equal(claims.identityBindingHex, identityBindingHex);
 const plain = Buffer.alloc(67 + claims.clientIcePwd.length);
 plain.writeUInt32BE(claims.expiresAt / 1000);
 Buffer.from(claims.clientFingerprintHex, 'hex').copy(plain, 4);
 plain.writeUInt16BE(claims.clientSctpPort, 36);
 plain.writeUInt32BE(claims.clientMaxMessageSize, 38);
-Buffer.from(claims.callerContextHashHex, 'hex').copy(plain, 42);
+Buffer.from(claims.identityBindingHex, 'hex').copy(plain, 42);
 plain.writeBigUInt64BE(BigInt(claims.networkId), 58);
 plain[66] = claims.clientIcePwd.length;
 plain.write(claims.clientIcePwd, 67, 'ascii');
@@ -62,7 +77,7 @@ const localUfrag = header + Buffer.concat([nonce, encrypted]).toString('base64')
 const icePwd = hmac(context.secret, `nxs-stateless-ice-v1\0${context.audience}\0${localUfrag}`).subarray(0, 24)
     .toString('base64');
 const expected = {localUfrag, icePwd, ufragLength: localUfrag.length};
-if (update) {
+if (updateAdmission) {
   v.expected = expected;
   write('stateless-admission-v1.fixtures.json', v);
 }
@@ -72,7 +87,7 @@ const provenance = {
   files: Object.fromEntries(['stateless-admission-v1.fixtures.json', 'cloudburst-protocol-vectors.v1.json'].map(
       name => [name, digest(readFileSync(path(name))).toString('hex')]))
 };
-if (update) write('provenance.json', provenance);
+if (updateAdmission) write('provenance.json', provenance);
 assert.deepEqual(read('provenance.json'), provenance);
 
 // Fleet examples keep public endpoint metadata optional and runtime counts independent.

--- a/docs/external-signalling/provenance.json
+++ b/docs/external-signalling/provenance.json
@@ -1,7 +1,7 @@
 {
   "specification": "urn:nethernet:external-signalling:v1",
   "files": {
-    "stateless-admission-v1.fixtures.json": "f84db8b78018cf3f5b910625414701f7c41bca1a5fa8056ff22c0d17df99301a",
+    "stateless-admission-v1.fixtures.json": "c718c8a12b9a7a769f0d122c4c686bb6940bdab9f691c1f82032a4a1364ec735",
     "cloudburst-protocol-vectors.v1.json": "2bd4c3305a0911f2d4a1166f1c6760ed6979c5af551cbd9660e9badd1f7fb993"
   }
 }

--- a/docs/external-signalling/stateless-admission-v1.fixtures.json
+++ b/docs/external-signalling/stateless-admission-v1.fixtures.json
@@ -14,16 +14,16 @@
     "clientIcePwd": "clientPassword01234567890",
     "clientSctpPort": 5000,
     "clientMaxMessageSize": 262144,
-    "callerContextHashHex": "abcdef0123456789abcdef0123456789",
-    "networkId": "18446744073709551615"
+    "networkId": "18446744073709551615",
+    "identityBindingHex": "8fce92d8c7d5707234735f69d4dd2f77"
   },
   "clientIceUfrag": "clientFixtureUf",
   "nonceHex": "000102030405060708090a0b",
   "now": 1788484800000,
   "maxTtlMs": 60000,
   "expected": {
-    "localUfrag": "NXS1K001AAECAwQFBgcICQoLVMAD+DMWY8K/TmtjsFluCDDdBa2hZL+TXNNyTD2z2mk9pDlsv7HZSWUQcYeCwa1spGxF25/EdEU8Qa7XN2qhYd9Ha7UENSp5AIMknX1jCS8Mw4joQSTW9M1qq5G/t+T8agkcuu9qluHVT/Am",
-    "icePwd": "hLPAsKmOEIGguJ3cJoj7OQqkkbLN6RWH",
+    "localUfrag": "NXS1K001AAECAwQFBgcICQoLVMAD+DMWY8K/TmtjsFluCDDdBa2hZL+TXNNyTD2z2mk9pDlsv7HZSWUQVYT/GEn8s5faZS+sg910v67XN2qhYd9Ha7UENSp5AIMknX1jCS8Mw4joQSTW9M1qq5Eh2HVrPM7uWCZr7sALLKAq",
+    "icePwd": "CGI2c8KAPFHovAp58OwHY/g/Xq3kDHHy",
     "ufragLength": 168
   },
   "budget": {
@@ -43,5 +43,20 @@
     "wrong-client-ufrag",
     "password-over-budget",
     "noncanonical-base64"
-  ]
+  ],
+  "identity": {
+    "publicKeyJwk": {
+      "key_ops": [
+        "verify"
+      ],
+      "ext": true,
+      "kty": "EC",
+      "x": "7onqrvcQqP_J5uJk-j3M7KhZqAB3OwxxFkg2XodPmV9KmC7ALcVeK0CQ-pJqX88F",
+      "y": "7mSiEjHsP4o6StG48-3Vvb2BfG8WTuYxmfrYmaS_CZDVHoWibgPWvmkGUbVQG9xq",
+      "crv": "P-384"
+    },
+    "canonicalCpk": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE7onqrvcQqP/J5uJk+j3M7KhZqAB3OwxxFkg2XodPmV9KmC7ALcVeK0CQ+pJqX88F7mSiEjHsP4o6StG48+3Vvb2BfG8WTuYxmfrYmaS/CZDVHoWibgPWvmkGUbVQG9xq",
+    "hmacInputHex": "6e78732d6964656e746974792d62696e64696e672d7631006e78732d73746174656c6573732d686f73742d76312f3031323334353637383961626364656630313233343536373839616263646566004d485977454159484b6f5a497a6a3043415159464b3445454143494459674145376f6e717276635171502f4a35754a6b2b6a334d374b685a714142334f777878466b6732586f64506d56394b6d4337414c6356654b3043512b704a7158383846376d5369456a487350346f3653744734382b33567662324266473857547559786d6672596d61532f435a4456486f576962675057766d6b475562565147397871",
+    "hmacSha256Hex": "8fce92d8c7d5707234735f69d4dd2f776ca75f8c6bff9cb925e42150da98b073"
+  }
 }

--- a/docs/external-signalling/wire-reference.md
+++ b/docs/external-signalling/wire-reference.md
@@ -391,10 +391,70 @@ data (AAD) is
 | 4 | 32 | SHA-256 client certificate fingerprint |
 | 36 | 2 | Client SCTP port, 1–65535 |
 | 38 | 4 | Client maximum message size, 1–262144 |
-| 42 | 16 | Opaque caller-context hash, no account-specific interpretation |
+| 42 | 16 | Identity binding: first 16 raw bytes of the HMAC below |
 | 58 | 8 | NetherNet network ID, unsigned 64-bit |
 | 66 | 1 | Client ICE password length, 22–91 |
 | 67 | N | Client ICE password in ICE base64 alphabet |
+
+### Bind signalling identity to the game login
+
+The provider MUST verify the client's signalling assertion, including its proof
+of possession over the offered DTLS fingerprint. It MUST derive the binding from
+that verified assertion's `cpk`, never from request headers or account metadata:
+
+```text
+identityBinding = HMAC-SHA256(secret,
+    UTF8("nxs-identity-binding-v1") || 0x00 || UTF8(audience) || 0x00 || UTF8(cpk))[0:16]
+```
+
+`secret` is the UTF-8 encoding of the installed ticket secret, **not** a base64
+decoding. `audience` is exactly `nxs-stateless-host-v1/<incarnation>`, as used for
+this ticket's encryption. `cpk` is standard base64 of canonical P-384 public-key
+SPKI DER: `id-ecPublicKey`, named curve `secp384r1`, and an uncompressed SEC1 point
+(`04 || X[48] || Y[48]`). Validate curve parameters and the point; normalize the
+validated key rather than retaining the client's original encoding. Standard
+base64 padding rules apply (this 120-byte SPKI needs no padding). The 16 raw MAC
+bytes occupy offset 42; hex is only a fixture/debug representation. No account
+identifier is encoded into or substituted for this binding.
+
+After normal Bedrock LoginPacket chain/token and client-data signature validation,
+the component terminating the direct client transport MUST canonicalize the
+validated login identity key the same way, recompute the MAC using the admitted
+ticket's secret and audience, and compare all 16 bytes in constant time. Reject
+missing, expired, revoked or mismatched binding evidence before accepting the
+player. Validity of the LoginPacket alone does not bind it to this transport.
+
+The reference `TransportIdentityBinding.mismatch(channel, validatedLoginKey)`
+helper handles both built-in signalling and NXS. Install its channel evidence
+before publishing the child. Consumers MUST invoke it at their validated login
+boundary; a library update alone cannot add an application login check.
+
+The verifier is one-shot. Retain the actual admitted key epoch until comparison,
+channel closure, rejection or the ticket's login deadline; do not look up the
+current secret by key ID later. Repeated key snapshots reuse unchanged epochs.
+Routine snapshot replacement/retirement stops new admissions but preserves pending
+comparisons, even if a key ID is reused. `StatelessAdmissionValidator.clear()`
+explicitly revokes installed and retained epochs and invalidates pending logins.
+Convert the remaining ticket lifetime to a monotonic deadline at admission. Opening
+data channels does not complete login; pending logins expire even after transport
+connection. Successful game sessions may outlive the ticket. Release retained
+material on capacity/replay rejection and failed native setup as well as channel
+closure. Admission principals expose no ticket secret or key handle.
+
+An explicitly configured trusted forwarding listener delegates player authentication
+to its proxy under its existing forwarding contract. A proxy may re-sign the
+backend chain, so the backend MUST NOT compare that chain to the original player's
+signalling key. Preserve that existing contract: after validating its forwarded
+fields, a consumer may call `TransportIdentityBinding.acceptForwardedIdentity`
+to complete the unused admission lifecycle. Do not infer forwarding from client
+fields or a missing/mismatched binding. The proxy terminating a direct NetherNet
+client is responsible for the equivalent signalling/login comparison there.
+This does not define a new proxy protocol or make untrusted forwarding safe.
+
+This pre-release change replaces the former opaque offset-42 field in NXS1 in
+place. Upgrade issuers and direct client terminators together; old tickets/issuers
+are not accepted as an identity-binding fallback. The wire size, carrier limit,
+DTLS verification, STUN integrity checks and unrelated RakNet handshake remain.
 
 The host's local ICE password is the unpadded standard base64 encoding of the
 first 24 bytes of

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/AdmissionGate.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/AdmissionGate.java
@@ -24,15 +24,16 @@ public final class AdmissionGate {
         private VerifiedAdmission admission;
         private final String tokenId;
         private final InetSocketAddress tuple;
-        private final long expiresAt, acceptedNanos;
+        private final long expiresAt, acceptedNanos, loginDeadlineNanos;
         private boolean ready, connected, closing, closed;
 
-        private Reservation(VerifiedAdmission admission, InetSocketAddress tuple, long nanos) {
+        private Reservation(VerifiedAdmission admission, InetSocketAddress tuple, long millis, long nanos) {
             this.admission = admission;
             this.tokenId = admission.tokenId();
             this.tuple = tuple;
             this.expiresAt = admission.expiresAt();
             this.acceptedNanos = nanos;
+            this.loginDeadlineNanos = nanos + (admission.expiresAt() - millis) * 1_000_000L;
         }
 
         public String tokenId() {
@@ -91,23 +92,27 @@ public final class AdmissionGate {
         }
         if (claims.containsKey(a.tokenId()) || tuples.containsKey(request.address())) {
             replayRejected++;
+            a.identityVerifier().close();
             return null;
         }
         if (draining) {
             capacityRejected++;
+            a.identityVerifier().close();
             return null;
         }
         if (pending >= limits.pending()) {
             capacityRejected++;
             pendingLimitRejected++;
             pendingAtRejection = pending;
+            a.identityVerifier().close();
             return null;
         }
         if (tuples.size() >= limits.sessions() || claims.size() >= limits.claims()) {
             capacityRejected++;
+            a.identityVerifier().close();
             return null;
         }
-        Reservation r = new Reservation(a, request.address(), nowNanos);
+        Reservation r = new Reservation(a, request.address(), nowMillis, nowNanos);
         claims.put(r.tokenId, r);
         tuples.put(r.tuple, r);
         pending++;
@@ -153,6 +158,7 @@ public final class AdmissionGate {
         }
         tuples.remove(r.tuple);
         r.closed = true;
+        r.admission.identityVerifier().close();
         r.admission = null;
         // A copied token with forged STUN integrity must not consume the real client's token.
         if (!r.ready || closed) {
@@ -171,8 +177,9 @@ public final class AdmissionGate {
     public synchronized List<Reservation> sweep(long nowMillis, long nowNanos) {
         List<Reservation> timedOut = new ArrayList<>();
         for (Reservation r : claims.values()) {
-            if (!r.closed && !r.closing && !r.connected
-                    && nowNanos - r.acceptedNanos >= limits.handshakeMillis() * 1_000_000L) {
+            if (!r.closed && !r.closing && (r.admission.identityVerifier().rejected()
+                    || (r.admission.identityVerifier().pending() && nowNanos - r.loginDeadlineNanos >= 0)
+                    || (!r.connected && nowNanos - r.acceptedNanos >= limits.handshakeMillis() * 1_000_000L))) {
                 r.closing = true;
                 timedOut.add(r);
             }
@@ -190,6 +197,7 @@ public final class AdmissionGate {
         List<Reservation> active = new ArrayList<>(tuples.values());
         for (Reservation r : active) {
             r.closing = true;
+            r.admission.identityVerifier().close();
         }
         claims.values().removeIf(r -> r.closed);
         return active;

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/AdmissionPrincipal.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/AdmissionPrincipal.java
@@ -5,7 +5,7 @@ import io.netty.util.AttributeKey;
 /**
  * Token-authenticated context bound to the certificate checked by native DTLS. No credentials.
  */
-public record AdmissionPrincipal(String ticketId, String networkId, String callerContextHash, String keyId) {
+public record AdmissionPrincipal(String ticketId, String networkId, String identityBindingHex, String keyId) {
     public static final AttributeKey<AdmissionPrincipal> KEY =
             AttributeKey.valueOf(AdmissionPrincipal.class, "principal");
 }

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/NativeAdmissionServerChannel.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/NativeAdmissionServerChannel.java
@@ -167,8 +167,9 @@ public final class NativeAdmissionServerChannel extends AbstractServerChannel {
                 "a=ice-ufrag:" + a.localUfrag() + "\r\n")) {
             throw new IllegalStateException("Native identity does not match published profile");
         }
+        org.cloudburstmc.netty.util.nethernet.TransportIdentityBinding.install(child, a.identityVerifier());
         child.attr(AdmissionPrincipal.KEY)
-                .set(new AdmissionPrincipal(a.tokenId(), a.networkId(), a.callerContextHash(), a.keyId()));
+                .set(new AdmissionPrincipal(a.tokenId(), a.networkId(), a.identityBindingHex(), a.keyId()));
         peer.onStateChange.register((p, state) -> {
             if (state == PeerState.RTC_FAILED || state == PeerState.RTC_CLOSED) {
                 session.failed = true;

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/StatelessAdmissionValidator.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/StatelessAdmissionValidator.java
@@ -1,6 +1,9 @@
 package org.cloudburstmc.netty.signalling.admission;
 
 
+import org.cloudburstmc.netty.util.nethernet.IdentityKeyVerifier;
+import java.util.function.LongSupplier;
+
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
 import javax.crypto.spec.GCMParameterSpec;
@@ -25,25 +28,80 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
         }
     }
 
-    private record Material(byte[] encryption, byte[] secret, long notBefore, long retireAfter) {
-        void erase() {
+    private static final class Material {
+        final byte[] encryption, secret;
+        final long notBefore, retireAfter;
+        private int references;
+        private boolean installed = true, revoked;
+
+        Material(byte[] encryption, byte[] secret, long notBefore, long retireAfter) {
+            this.encryption = encryption;
+            this.secret = secret;
+            this.notBefore = notBefore;
+            this.retireAfter = retireAfter;
+        }
+
+        synchronized void retain() { references++; }
+        synchronized void release() { references--; eraseIfUnused(); }
+        synchronized void retire() { installed = false; eraseIfUnused(); }
+        synchronized boolean usable() { return !revoked; }
+        synchronized void revoke() {
+            revoked = true;
             Arrays.fill(encryption, (byte) 0);
             Arrays.fill(secret, (byte) 0);
+        }
+        private void eraseIfUnused() { if (!installed && references == 0) revoke(); }
+        synchronized boolean unused() { return !installed && references == 0; }
+        synchronized boolean matches(String audience, byte[] canonicalKey, byte[] expected) {
+            if (revoked) return false;
+            byte[] actual = hmac("HmacSHA256", secret, utf8("nxs-identity-binding-v1\0" + audience + "\0"
+                    + Base64.getEncoder().encodeToString(canonicalKey)));
+            try { return MessageDigest.isEqual(expected, Arrays.copyOf(actual, 16)); }
+            finally { Arrays.fill(actual, (byte) 0); }
+        }
+    }
+
+    private final class Binding extends IdentityKeyVerifier {
+        private final Material material;
+        private final byte[] expected;
+        private final long deadlineNanos;
+
+        Binding(Material material, byte[] expected, long ttlMillis) {
+            this.material = material;
+            this.expected = expected;
+            this.deadlineNanos = nanoTime.getAsLong() + ttlMillis * 1_000_000L;
+            material.retain();
+        }
+
+        protected boolean usable() {
+            return nanoTime.getAsLong() - deadlineNanos < 0 && material.usable();
+        }
+        protected boolean matches(byte[] key) { return material.matches(audience, key, expected); }
+        protected void release() {
+            Arrays.fill(expected, (byte) 0);
+            material.release();
         }
     }
 
     private static final Base64.Encoder BASE64 = Base64.getEncoder().withoutPadding();
     private final String audience;
     private final long maxTtlMs;
+    private final LongSupplier nanoTime;
+    private final Set<Material> epochs = new HashSet<>();
     private volatile Map<String, Material> keys = Map.of();
 
     public StatelessAdmissionValidator(String audience, long maxTtlMs) {
+        this(audience, maxTtlMs, System::nanoTime);
+    }
+
+    StatelessAdmissionValidator(String audience, long maxTtlMs, LongSupplier nanoTime) {
         if (audience == null || audience.isEmpty() || audience.length() > 512 || audience.indexOf(0) >= 0
                 || maxTtlMs <= 0 || maxTtlMs > 120_000) {
             throw new IllegalArgumentException("Admission context");
         }
         this.audience = audience;
         this.maxTtlMs = maxTtlMs;
+        this.nanoTime = Objects.requireNonNull(nanoTime);
     }
 
     /**
@@ -53,33 +111,47 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
         if (snapshot.size() > 8) {
             throw new IllegalArgumentException("At most eight admission epochs");
         }
-        Map<String, Material> next = new HashMap<>();
+        Set<String> ids = new HashSet<>();
         for (TicketKey key : snapshot) {
             if (key.keyId() == null || !key.keyId().matches("[A-Z0-9]{4}") || key.secret() == null
-                    || key.secret().length() < 32 || key.secret().length() > 256 || next.containsKey(key.keyId())
+                    || key.secret().length() < 32 || key.secret().length() > 256 || !ids.add(key.keyId())
                     || key.notBefore() < 0 || key.retireAfter() <= key.notBefore()) {
                 throw new IllegalArgumentException("Invalid admission key snapshot");
             }
-            byte[] secret = utf8(key.secret());
-            next.put(key.keyId(),
-                    new Material(hmac("HmacSHA256", secret, utf8("nxs-stateless-aead-v1\0" + audience)), secret,
-                            key.notBefore(), key.retireAfter()));
         }
-        Map<String, Material> previous = keys;
+        Map<String, Material> next = new HashMap<>();
+        try {
+            for (TicketKey key : snapshot) {
+                byte[] secret = utf8(key.secret());
+                Material previous = keys.get(key.keyId());
+                if (previous != null && previous.notBefore == key.notBefore() && previous.retireAfter == key.retireAfter()
+                        && MessageDigest.isEqual(previous.secret, secret)) {
+                    Arrays.fill(secret, (byte) 0);
+                    next.put(key.keyId(), previous);
+                } else {
+                    next.put(key.keyId(), new Material(hmac("HmacSHA256", secret,
+                            utf8("nxs-stateless-aead-v1\0" + audience)), secret, key.notBefore(), key.retireAfter()));
+                }
+            }
+        } catch (RuntimeException failed) {
+            next.values().stream().filter(m -> !keys.containsValue(m)).forEach(Material::retire);
+            throw failed;
+        }
+        keys.values().stream().filter(m -> !next.containsValue(m)).forEach(Material::retire);
         keys = Map.copyOf(next);
-        previous.values().forEach(Material::erase);
+        epochs.addAll(next.values());
+        epochs.removeIf(Material::unused);
     }
 
+    /** Routine rotation stops new admissions; admitted logins retain their original epoch until completion/expiry. */
     public synchronized void retireKeys(long nowMillis) {
         Map<String, Material> retained = new HashMap<>();
         for (var entry : keys.entrySet()) {
-            if (entry.getValue().retireAfter() <= nowMillis) {
-                entry.getValue().erase();
-            } else {
-                retained.put(entry.getKey(), entry.getValue());
-            }
+            if (entry.getValue().retireAfter <= nowMillis) entry.getValue().retire();
+            else retained.put(entry.getKey(), entry.getValue());
         }
         keys = Map.copyOf(retained);
+        epochs.removeIf(Material::unused);
     }
 
     public boolean ready() {
@@ -90,8 +162,10 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
         return keys.keySet();
     }
 
+    /** Revoke all installed and retained epochs, including pending logins. */
     public synchronized void clear() {
-        keys.values().forEach(Material::erase);
+        epochs.forEach(Material::revoke);
+        epochs.clear();
         keys = Map.of();
     }
 
@@ -108,7 +182,7 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
             }
             String keyId = token.substring(4, 8);
             Material key = keys.get(keyId);
-            if (key == null || nowMillis < key.notBefore() || nowMillis >= key.retireAfter()) {
+            if (key == null || nowMillis < key.notBefore || nowMillis >= key.retireAfter) {
                 return null;
             }
             String encoded = token.substring(8);
@@ -117,7 +191,7 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
                 return null;
             }
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key.encryption(), "AES"),
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key.encryption, "AES"),
                     new GCMParameterSpec(128, Arrays.copyOf(envelope, 12)));
             cipher.updateAAD(utf8("nxs-stateless-admission-v1\0" + token.substring(0, 8) + "\0" + audience + "\0"
                     + request.remoteUfrag()));
@@ -145,11 +219,11 @@ public final class StatelessAdmissionValidator implements AdmissionValidator {
                 return null;
             }
             String localPassword = BASE64.encodeToString(Arrays.copyOf(
-                    hmac("HmacSHA256", key.secret(), utf8("nxs-stateless-ice-v1\0" + audience + "\0" + token)), 24));
+                    hmac("HmacSHA256", key.secret, utf8("nxs-stateless-ice-v1\0" + audience + "\0" + token)), 24));
             return new VerifiedAdmission(tokenId(token), token, localPassword, request.remoteUfrag(), remotePassword,
                     "sha-256 " + HexFormat.ofDelimiter(":").withUpperCase().formatHex(fingerprint), sctp, max,
                     expiresAt,
-                    networkId, HexFormat.of().formatHex(identity), keyId);
+                    networkId, HexFormat.of().formatHex(identity), keyId, new Binding(key, identity, expiresAt - nowMillis));
         } catch (Exception invalid) {
             return null;
         } finally {

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/VerifiedAdmission.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/admission/VerifiedAdmission.java
@@ -1,13 +1,17 @@
 package org.cloudburstmc.netty.signalling.admission;
 
+import org.cloudburstmc.netty.util.nethernet.IdentityKeyVerifier;
+import java.util.Objects;
+
 /**
  * Trusted validator output. Never log credentials or reconstructed SDP.
  */
 public record VerifiedAdmission(String tokenId, String localUfrag, String localPassword,
                                 String remoteUfrag, String remotePassword, String remoteFingerprint,
                                 int remoteSctpPort, int remoteMaxMessageSize, long expiresAt,
-                                String networkId, String callerContextHash, String keyId) {
+                                String networkId, String identityBindingHex, String keyId, IdentityKeyVerifier identityVerifier) {
     public VerifiedAdmission {
+        Objects.requireNonNull(identityVerifier, "identityVerifier");
         if (tokenId == null || !tokenId.matches("[0-9a-f]{32}")) {
             throw new IllegalArgumentException("tokenId");
         }

--- a/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/provider/ProviderRuntimeObservations.java
+++ b/external-signalling/src/main/java/org/cloudburstmc/netty/signalling/provider/ProviderRuntimeObservations.java
@@ -1,6 +1,7 @@
 package org.cloudburstmc.netty.signalling.provider;
 
 import com.google.gson.JsonObject;
+import java.net.URI;
 import org.cloudburstmc.netty.signalling.ProviderClient;
 
 /**
@@ -23,6 +24,12 @@ public final class ProviderRuntimeObservations {
         return new ProviderClient.Health(true, acceptingPlayers, capacity,
                 Math.min(1, (double) connectedPlayers / Math.max(1, capacity)), "nethernet", build,
                 new ProviderClient.PlayerCount(connectedPlayers, sampledAt));
+    }
+
+    /** Describes the trust boundary without logging provider credentials or URL query data. */
+    public static String delegatedIdentityMessage(URI origin) {
+        return "NetherNet client identities are authenticated by external signalling provider " + origin.getHost()
+                + "; direct login keys are checked against its admission tickets";
     }
 
     public static String registrationMessage(JsonObject registration) {

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/AdmissionGateTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/AdmissionGateTest.java
@@ -77,6 +77,7 @@ class AdmissionGateTest extends AdmissionFixture {
         var r = gate.reserve(request(), now, 0);
         assertTrue(gate.ready(r));
         gate.connected(r);
+        assertNull(gate.admission(r).identityVerifier().acceptForwardedIdentity());
         assertNull(gate.reserve(elsewhere(), now, 0));
         assertEquals(1, gate.stats().replayRejected());
         assertTrue(gate.sweep(now + 120_000, 120_000_000_000L).isEmpty());

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/IdentityBindingTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/IdentityBindingTest.java
@@ -1,0 +1,134 @@
+package org.cloudburstmc.netty.signalling.admission;
+
+import org.cloudburstmc.netty.util.nethernet.IdentityPublicKey;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdentityBindingTest extends AdmissionFixture {
+    PublicKey key() throws Exception {
+        return KeyFactory.getInstance("EC").generatePublic(new X509EncodedKeySpec(Base64.getDecoder()
+                .decode(f.getAsJsonObject("identity").get("canonicalCpk").getAsString())));
+    }
+
+    StatelessAdmissionValidator.TicketKey epoch() {
+        return new StatelessAdmissionValidator.TicketKey("K001", f.getAsJsonObject("context").get("secret").getAsString());
+    }
+
+    @Test
+    void canonicalNodeKeyAcceptsExactlyOneLoginAndDifferentKeyIsRejected() throws Exception {
+        assertEquals(f.getAsJsonObject("identity").get("canonicalCpk").getAsString(),
+                Base64.getEncoder().encodeToString(IdentityPublicKey.canonical(key())));
+        var admitted = validator().validate(request(), now).identityVerifier();
+        assertNull(admitted.mismatch(key()));
+        assertFalse(admitted.pending());
+        assertFalse(admitted.rejected());
+        assertNotNull(admitted.mismatch(key()));
+        var generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp384r1"));
+        var other = validator().validate(request(), now).identityVerifier();
+        assertNotNull(other.mismatch(generator.generateKeyPair().getPublic()));
+        assertTrue(other.rejected());
+        assertNotNull(other.mismatch(key()));
+    }
+
+    @Test
+    void unsupportedAndMissingKeysFailClosed() throws Exception {
+        var generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        assertNotNull(validator().validate(request(), now).identityVerifier().mismatch(generator.generateKeyPair().getPublic()));
+        assertNotNull(validator().validate(request(), now).identityVerifier().mismatch(null));
+    }
+
+    @Test
+    void refreshRotationAndSameIdReplacementKeepTheActualAdmittedEpoch() throws Exception {
+        var v = validator();
+        var refresh = v.validate(request(), now).identityVerifier();
+        v.installKeys(List.of(epoch()));
+        assertNull(refresh.mismatch(key()));
+        var replaced = v.validate(request(), now).identityVerifier();
+        v.installKeys(List.of(new StatelessAdmissionValidator.TicketKey("K001", "replacement-secret-at-least-thirty-two-characters")));
+        assertNull(v.validate(request(), now));
+        assertNull(replaced.mismatch(key()));
+        v.installKeys(List.of(new StatelessAdmissionValidator.TicketKey("K001", epoch().secret(), now, now + 1000)));
+        var retired = v.validate(request(), now).identityVerifier();
+        v.retireKeys(now + 1000);
+        assertFalse(v.ready());
+        assertNull(retired.mismatch(key()));
+    }
+
+    @Test
+    void clearAlsoRevokesRetainedEpochsAndCloseIsIdempotent() throws Exception {
+        var v = validator();
+        var retired = v.validate(request(), now).identityVerifier();
+        v.installKeys(List.of());
+        v.clear();
+        assertTrue(retired.rejected());
+        assertNotNull(retired.mismatch(key()));
+        v.installKeys(List.of(epoch()));
+        var closed = v.validate(request(), now).identityVerifier();
+        closed.close();
+        closed.close();
+        assertNotNull(closed.mismatch(key()));
+    }
+
+    @Test
+    void pendingDeadlineIsMonotonicAndCompletedForwardingSurvivesExpiry() throws Exception {
+        var nanos = new AtomicLong(0);
+        var v = new StatelessAdmissionValidator(f.getAsJsonObject("context").get("audience").getAsString(), 60_000, nanos::get);
+        v.installKeys(List.of(epoch()));
+        var pending = v.validate(request(), now).identityVerifier();
+        var forwarded = v.validate(request(), now).identityVerifier();
+        assertNull(forwarded.acceptForwardedIdentity());
+        nanos.set(30_000_000_000L);
+        assertTrue(pending.rejected());
+        assertNotNull(pending.mismatch(key()));
+        assertFalse(forwarded.rejected());
+        assertFalse(forwarded.pending());
+    }
+
+    @Test
+    void connectedWithoutLoginTimesOutButVerifiedAndForwardedSessionsContinue() throws Exception {
+        for (int mode = 0; mode < 3; mode++) {
+            var gate = new AdmissionGate(AdmissionGate.Limits.defaults(), validator());
+            var r = gate.reserve(request(), now, 0);
+            var binding = gate.admission(r).identityVerifier();
+            assertTrue(gate.ready(r));
+            gate.connected(r);
+            if (mode == 1) assertNull(binding.mismatch(key()));
+            if (mode == 2) assertNull(binding.acceptForwardedIdentity());
+            assertEquals(mode == 0 ? List.of(r) : List.of(), gate.sweep(now + 30_000, 30_000_000_000L));
+            gate.finish(r);
+            assertFalse(binding.pending());
+        }
+    }
+
+    @Test
+    void reserveRejectionAndNativeFailureReleaseTheirOwnBinding() {
+        var v = validator();
+        var issued = new java.util.ArrayList<VerifiedAdmission>();
+        var gate = new AdmissionGate(AdmissionGate.Limits.defaults(), (request, time) -> {
+            var a = v.validate(request, time);
+            issued.add(a);
+            return a;
+        });
+        var accepted = gate.reserve(request(), now, 0);
+        assertNull(gate.reserve(request(), now, 0));
+        assertFalse(issued.get(1).identityVerifier().pending());
+        assertTrue(issued.get(0).identityVerifier().pending());
+        gate.finish(accepted);
+        assertFalse(issued.get(0).identityVerifier().pending());
+        gate.drain();
+        assertNull(gate.reserve(request(), now, 0));
+        assertFalse(issued.get(2).identityVerifier().pending());
+    }
+}

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/NativeAdmissionIntegrationTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/NativeAdmissionIntegrationTest.java
@@ -33,6 +33,59 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("native")
 class NativeAdmissionIntegrationTest {
     @Test
+    @Timeout(40)
+    void transportPublishesBindingBeforeLoginAndRejectsADifferentKey() throws Exception {
+        var id = identity();
+        var group = new DefaultEventLoopGroup(1);
+        var validator = new StatelessAdmissionValidator(TestSignallingProvider.AUDIENCE, 60_000);
+        validator.installKeys(List.of(new StatelessAdmissionValidator.TicketKey("K001", TestSignallingProvider.SECRET)));
+        var endpoint = new NativeAdmissionServerChannel(id, validator, AdmissionGate.Limits.defaults());
+        var results = new LinkedBlockingQueue<Boolean>();
+        try {
+            new ServerBootstrap().group(group).channelFactory(() -> endpoint)
+                    .childHandler(new ChannelInitializer<AdmittedNetherNetChildChannel>() {
+                        protected void initChannel(AdmittedNetherNetChildChannel child) {
+                            child.pipeline().addLast(new SimpleChannelInboundHandler<ByteBuf>() {
+                                protected void channelRead0(ChannelHandlerContext ctx, ByteBuf message) throws Exception {
+                                    var key = java.security.KeyFactory.getInstance("EC").generatePublic(
+                                            new java.security.spec.X509EncodedKeySpec(ByteBufUtil.getBytes(message)));
+                                    String mismatch = org.cloudburstmc.netty.util.nethernet.TransportIdentityBinding.mismatch(child, key);
+                                    results.add(mismatch == null);
+                                    if (mismatch != null) ctx.close();
+                                }
+                            });
+                        }
+                    }).bind("127.0.0.1", 49201).sync();
+            var generator = java.security.KeyPairGenerator.getInstance("EC");
+            generator.initialize(new java.security.spec.ECGenParameterSpec("secp384r1"));
+            for (boolean matching : new boolean[]{true, false}) {
+                byte[] loginKey = matching ? Base64.getDecoder().decode(TestSignallingProvider.IDENTITY_CPK)
+                        : generator.generateKeyPair().getPublic().getEncoded();
+                try (var client = PeerConnection.createPeer(PeerConnectionConfiguration.DEFAULT
+                        .withDisableAutoNegotiation(true).withBindAddress(InetAddress.getLoopbackAddress()), Runnable::run)) {
+                    var reliable = client.createDataChannel("ReliableDataChannel");
+                    client.createDataChannel("UnreliableDataChannel", DataChannelInitSettings.DEFAULT.withReliability(
+                            new DataChannelReliability(true, true, 0, 0)));
+                    reliable.onOpen.register(dc -> dc.sendMessage(ByteBuffer.allocateDirect(1 + loginKey.length)
+                            .put((byte) 0).put(loginKey).flip()));
+                    client.setLocalDescription("offer", "identityClient" + matching, "p".repeat(32));
+                    var answer = TestSignallingProvider.answer(client.localDescription(), id.fingerprint(), 49201,
+                            System.currentTimeMillis() + 30_000, TestSignallingProvider.AUDIENCE, false);
+                    client.setRemoteDescription(answer.sdp(), SessionDescriptionType.ANSWER);
+                    assertEquals(matching, results.poll(12, TimeUnit.SECONDS));
+                    assertTrue(client.closeAndAwait(Duration.ofSeconds(5)));
+                }
+            }
+            assertEquals(2, endpoint.creationAttempts());
+            System.out.println("native-identity-binding PASS matchingKey=true capturedOtherKeyRejected=true");
+        } finally {
+            endpoint.close().awaitUninterruptibly();
+            endpoint.termination().toCompletableFuture().get(6, TimeUnit.SECONDS);
+            group.shutdownGracefully(0, 1, TimeUnit.SECONDS).sync();
+        }
+    }
+
+    @Test
     @Timeout(30)
     void dualStackWildcardAcceptsBothFamiliesAndRetainsSingleTicketOwnership() throws Exception {
         var id = identity();

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/StatelessAdmissionValidatorTest.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/StatelessAdmissionValidatorTest.java
@@ -81,7 +81,7 @@ class StatelessAdmissionValidatorTest extends AdmissionFixture {
         assertEquals(c.get("clientIcePwd").getAsString(), a.remotePassword());
         assertEquals(c.get("clientSctpPort").getAsInt(), a.remoteSctpPort());
         assertEquals(c.get("networkId").getAsString(), a.networkId());
-        assertEquals(c.get("callerContextHashHex").getAsString(), a.callerContextHash());
+        assertEquals(c.get("identityBindingHex").getAsString(), a.identityBindingHex());
         assertEquals(password, a.localPassword());
         assertEquals(c.get("clientFingerprintHex").getAsString(),
                 a.remoteFingerprint().substring(8).replace(":", "").toLowerCase(Locale.ROOT));

--- a/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/TestSignallingProvider.java
+++ b/external-signalling/src/test/java/org/cloudburstmc/netty/signalling/admission/TestSignallingProvider.java
@@ -11,6 +11,8 @@ import java.util.*;
  * Test signalling source. Offer and issued token are NEVER delivered to the host.
  */
 final class TestSignallingProvider {
+    static final String IDENTITY_CPK = AdmissionFixture.fixture("stateless-admission-v1.fixtures.json")
+            .getAsJsonObject("identity").get("canonicalCpk").getAsString();
     static final String AUDIENCE = "sig_fixture/gs_one/test_boot_001", SECRET =
             "stateless-fixture-secret-32-bytes-minimum";
 
@@ -43,8 +45,9 @@ final class TestSignallingProvider {
         if (wrongClientFingerprint) {
             fp[0] ^= 1;
         }
+        byte[] identityBinding = Arrays.copyOf(hmac(utf8(SECRET), "nxs-identity-binding-v1\0" + audience + "\0" + IDENTITY_CPK), 16);
         ByteBuffer claims = ByteBuffer.allocate(67 + pwd.length());
-        claims.putInt((int) (expiry / 1000)).put(fp).putShort((short) 5000).putInt(262144).put(new byte[16]).putLong(42)
+        claims.putInt((int) (expiry / 1000)).put(fp).putShort((short) 5000).putInt(262144).put(identityBinding).putLong(42)
                 .put((byte) pwd.length()).put(utf8(pwd));
         byte[] nonce = new byte[12];
         new SecureRandom().nextBytes(nonce);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ jspecify = { group = "org.jspecify", name = "jspecify", version = "1.0.0" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit" }
-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "1.9.2" }
 
 
 [bundles]

--- a/transport-nethernet/src/main/java/org/cloudburstmc/netty/channel/nethernet/NetherNetServerChannel.java
+++ b/transport-nethernet/src/main/java/org/cloudburstmc/netty/channel/nethernet/NetherNetServerChannel.java
@@ -121,6 +121,8 @@ public class NetherNetServerChannel extends AbstractServerChannel {
      */
     public void acceptConnection(long connectionId, String offerSdp, String remoteNetworkId,
                                  @Nullable InetSocketAddress clientAddress, @Nullable PlayerInfo player) {
+        var identityVerifier = player == null ? null
+                : org.cloudburstmc.netty.util.nethernet.TransportIdentityBinding.forPlayer(player);
         PeerConnectionConfiguration rtcConfig =
                 bindIce(this.config.getOption(NetherChannelOption.NETHER_PEER_CONNECTION_CONFIG))
                         .withDisableAutoNegotiation(true)
@@ -138,6 +140,7 @@ public class NetherNetServerChannel extends AbstractServerChannel {
         child.attr(NetherNetChildChannel.CONNECTION_ID).set(connectionId);
         if (player != null) {
             child.attr(NetherNetChildChannel.PLAYER_INFO).set(player);
+            org.cloudburstmc.netty.util.nethernet.TransportIdentityBinding.install(child, identityVerifier);
         }
         observer.setChildChannel(child);
 

--- a/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/IdentityKeyVerifier.java
+++ b/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/IdentityKeyVerifier.java
@@ -1,0 +1,50 @@
+package org.cloudburstmc.netty.util.nethernet;
+
+import java.security.PublicKey;
+
+/** One login decision, owned by a transport channel. Never exposes admission secrets. */
+public abstract class IdentityKeyVerifier implements AutoCloseable {
+    private enum State { PENDING, ACCEPTED, REJECTED, CLOSED }
+    private State state = State.PENDING;
+
+    public final synchronized String mismatch(PublicKey key) {
+        if (state != State.PENDING) return "the transport identity binding has already been consumed";
+        boolean accepted = false;
+        try {
+            accepted = usable() && matches(IdentityPublicKey.canonical(key));
+            return accepted ? null : "the login key does not match the admitted transport identity";
+        } catch (Exception invalid) {
+            return "the transport or login identity key is invalid";
+        } finally {
+            state = accepted ? State.ACCEPTED : State.REJECTED;
+            release();
+        }
+    }
+
+    /** Only for an application's already authenticated, explicitly trusted forwarding path. */
+    public final synchronized String acceptForwardedIdentity() {
+        if (state != State.PENDING) return "the transport identity binding has already been consumed";
+        boolean accepted = usable();
+        state = accepted ? State.ACCEPTED : State.REJECTED;
+        release();
+        return accepted ? null : "the transport identity binding has expired or been revoked";
+    }
+
+    public final synchronized boolean pending() { return state == State.PENDING; }
+
+    public final synchronized boolean rejected() {
+        return state == State.REJECTED || state == State.CLOSED || (state == State.PENDING && !usable());
+    }
+
+    @Override
+    public final synchronized void close() {
+        if (state == State.PENDING) {
+            state = State.CLOSED;
+            release();
+        }
+    }
+
+    protected boolean usable() { return true; }
+    protected abstract boolean matches(byte[] canonicalKey);
+    protected abstract void release();
+}

--- a/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/IdentityPublicKey.java
+++ b/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/IdentityPublicKey.java
@@ -1,0 +1,53 @@
+package org.cloudburstmc.netty.util.nethernet;
+
+import java.math.BigInteger;
+import java.security.AlgorithmParameters;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECFieldFp;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+/** Canonical named secp384r1 SPKI DER, with an uncompressed and validated public point. */
+public final class IdentityPublicKey {
+    private static final ECParameterSpec CURVE;
+    private static final byte[] PREFIX = HexFormat.of().parseHex("3076301006072a8648ce3d020106052b8104002203620004");
+    static {
+        try {
+            AlgorithmParameters parameters = AlgorithmParameters.getInstance("EC");
+            parameters.init(new ECGenParameterSpec("secp384r1"));
+            CURVE = parameters.getParameterSpec(ECParameterSpec.class);
+        } catch (Exception e) { throw new ExceptionInInitializerError(e); }
+    }
+
+    private IdentityPublicKey() { }
+
+    public static byte[] canonical(PublicKey key) {
+        if (!(key instanceof ECPublicKey ec)) throw new IllegalArgumentException("Expected an EC public key");
+        ECParameterSpec params = ec.getParams();
+        if (params == null || !CURVE.getCurve().equals(params.getCurve())
+                || !CURVE.getGenerator().equals(params.getGenerator())
+                || !CURVE.getOrder().equals(params.getOrder()) || CURVE.getCofactor() != params.getCofactor()) {
+            throw new IllegalArgumentException("Expected secp384r1");
+        }
+        BigInteger x = ec.getW().getAffineX(), y = ec.getW().getAffineY();
+        BigInteger p = ((ECFieldFp) CURVE.getCurve().getField()).getP();
+        if (x == null || y == null || x.signum() < 0 || y.signum() < 0 || x.compareTo(p) >= 0 || y.compareTo(p) >= 0
+                || !y.multiply(y).mod(p).equals(x.pow(3).add(CURVE.getCurve().getA().multiply(x))
+                .add(CURVE.getCurve().getB()).mod(p))) {
+            throw new IllegalArgumentException("Invalid secp384r1 point");
+        }
+        byte[] result = Arrays.copyOf(PREFIX, 120);
+        coordinate(x, result, PREFIX.length);
+        coordinate(y, result, PREFIX.length + 48);
+        return result;
+    }
+
+    private static void coordinate(BigInteger value, byte[] target, int offset) {
+        byte[] bytes = value.toByteArray();
+        int length = Math.min(48, bytes.length);
+        System.arraycopy(bytes, bytes.length - length, target, offset + 48 - length, length);
+    }
+}

--- a/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/TransportIdentityBinding.java
+++ b/transport-nethernet/src/main/java/org/cloudburstmc/netty/util/nethernet/TransportIdentityBinding.java
@@ -1,6 +1,9 @@
 package org.cloudburstmc.netty.util.nethernet;
 
 import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+import java.security.MessageDigest;
+import java.util.Arrays;
 import org.cloudburstmc.netty.channel.nethernet.NetherNetChildChannel;
 
 import java.security.PublicKey;
@@ -21,6 +24,35 @@ import java.security.PublicKey;
  */
 public final class TransportIdentityBinding {
 
+    private static final AttributeKey<IdentityKeyVerifier> KEY = AttributeKey.valueOf(TransportIdentityBinding.class, "verifier");
+
+    /** Install before publishing the child. The channel and admission owner may both close it. */
+    public static void install(Channel channel, IdentityKeyVerifier verifier) {
+        if (verifier == null) throw new IllegalArgumentException("verifier");
+        if (channel.attr(KEY).setIfAbsent(verifier) != null) {
+            verifier.close();
+            throw new IllegalStateException("Identity binding already installed");
+        }
+        channel.closeFuture().addListener(ignored -> verifier.close());
+    }
+
+    public static IdentityKeyVerifier forPlayer(PlayerInfo player) {
+        final byte[] expected;
+        try { expected = IdentityPublicKey.canonical(player.clientPublicKey()); }
+        catch (Exception invalid) { throw new IllegalArgumentException("Invalid signalling identity", invalid); }
+        return new IdentityKeyVerifier() {
+            protected boolean matches(byte[] key) { return MessageDigest.isEqual(expected, key); }
+            protected void release() { Arrays.fill(expected, (byte) 0); }
+        };
+    }
+
+    /** Release only after the application has accepted its existing trusted forwarding identity. */
+    public static String acceptForwardedIdentity(Channel channel) {
+        if (!(channel instanceof NetherNetChildChannel)) return null;
+        IdentityKeyVerifier verifier = channel.attr(KEY).get();
+        return verifier == null ? null : verifier.acceptForwardedIdentity();
+    }
+
     private TransportIdentityBinding() {
     }
 
@@ -34,7 +66,8 @@ public final class TransportIdentityBinding {
             // RakNet binds the chain through the encryption handshake instead
             return null;
         }
-        return mismatch(channel.attr(NetherNetChildChannel.PLAYER_INFO).get(), identityPublicKey);
+        IdentityKeyVerifier verifier = channel.attr(KEY).get();
+        return verifier == null ? "the transport carries no validated identity binding" : verifier.mismatch(identityPublicKey);
     }
 
     /**
@@ -48,7 +81,7 @@ public final class TransportIdentityBinding {
         }
 
         try {
-            if (!player.clientPublicKey().equals(identityPublicKey)) {
+            if (!MessageDigest.isEqual(IdentityPublicKey.canonical(player.clientPublicKey()), IdentityPublicKey.canonical(identityPublicKey))) {
                 return "the login chain is signed with a different key than the one that opened the transport";
             }
         } catch (Exception e) {

--- a/transport-nethernet/src/test/java/org/cloudburstmc/netty/util/nethernet/TransportIdentityBindingTest.java
+++ b/transport-nethernet/src/test/java/org/cloudburstmc/netty/util/nethernet/TransportIdentityBindingTest.java
@@ -1,0 +1,65 @@
+package org.cloudburstmc.netty.util.nethernet;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.jose4j.jwt.JwtClaims;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.ECParameterSpec;
+import java.security.spec.ECPoint;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TransportIdentityBindingTest {
+    @Test
+    void builtInSignallingUsesTheSameOneShotCanonicalComparison() throws Exception {
+        var generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp384r1"));
+        var original = (ECPublicKey) generator.generateKeyPair().getPublic();
+        var claims = new JwtClaims();
+        claims.setStringClaim("cpk", Base64.getEncoder().encodeToString(original.getEncoded()));
+        var player = new PlayerInfo("same-xuid", "fixture", "42", null, claims);
+        ECPublicKey otherProvider = new ECPublicKey() {
+            public ECPoint getW() { return original.getW(); }
+            public ECParameterSpec getParams() { return original.getParams(); }
+            public String getAlgorithm() { return "EC"; }
+            public String getFormat() { return "provider-specific"; }
+            public byte[] getEncoded() { return null; }
+        };
+        assertNotEquals(original, otherProvider);
+        var verifier = TransportIdentityBinding.forPlayer(player);
+        assertNull(verifier.mismatch(otherProvider));
+        assertNotNull(verifier.mismatch(original));
+        assertNotNull(TransportIdentityBinding.forPlayer(player).mismatch(generator.generateKeyPair().getPublic()));
+        assertNotNull(TransportIdentityBinding.mismatch((PlayerInfo) null, original));
+    }
+
+    @Test
+    void invalidCurveAndOffCurvePointAreRejected() throws Exception {
+        var generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        assertThrows(IllegalArgumentException.class, () -> IdentityPublicKey.canonical(generator.generateKeyPair().getPublic()));
+        generator.initialize(new ECGenParameterSpec("secp384r1"));
+        var key = (ECPublicKey) generator.generateKeyPair().getPublic();
+        ECPublicKey invalid = new ECPublicKey() {
+            public ECPoint getW() { return new ECPoint(java.math.BigInteger.ZERO, java.math.BigInteger.ZERO); }
+            public ECParameterSpec getParams() { return key.getParams(); }
+            public String getAlgorithm() { return "EC"; }
+            public String getFormat() { return "X.509"; }
+            public byte[] getEncoded() { return key.getEncoded(); }
+        };
+        assertThrows(IllegalArgumentException.class, () -> IdentityPublicKey.canonical(invalid));
+    }
+
+    @Test
+    void nonNetherNetChannelsContinueUsingTheirExistingAuthentication() {
+        var channel = new EmbeddedChannel();
+        try {
+            assertNull(TransportIdentityBinding.mismatch(channel, null));
+            assertNull(TransportIdentityBinding.acceptForwardedIdentity(channel));
+        } finally { channel.finishAndReleaseAll(); }
+    }
+}


### PR DESCRIPTION
NXS admission currently authenticates the transport without carrying evidence that its separately validated Bedrock LoginPacket belongs to the signalling CPK. A hostile server can therefore present a captured LoginPacket on a connection opened with another key.

Replace NXS1's opaque offset-42 field in place with the first 16 bytes of `HMAC-SHA256(UTF8(secret), "nxs-identity-binding-v1" || NUL || audience || NUL || canonicalCpk)`. The wire reference and independent Node fixtures specify canonical P-384 SPKI/base64 and exact HMAC bytes. Carrier size is unchanged.

The shared channel verifier supports built-in signalling and native NXS admission. It retains the actual admitted key epoch across rotation, rejects mismatches/repeated checks/expired or revoked evidence, and releases ownership on rejection and closure. Connected transports still awaiting login expire; completed direct or explicitly trusted forwarded sessions can outlive their ticket. Consumers must call the helper after normal game-login validation. Forwarding policy remains with the configured application/proxy.

Also supply the delegated-identity logging helper already called by Chris's Geyser branch, and pin the previously unversioned JUnit platform launcher so the test tasks resolve.

Validation: protocol/identity/gate tests, full transport and external-signalling suites, real native matching/different-key rejection, Worker/native and provider/native probes, and Geyser core tests. Independent security patch review found no reportable issue. These tests do not establish stock-client gameplay or a complete captured LoginPacket replay against live Geyser.

AI-assisted implementation, review and test execution. Coordinated pre-release issuer/consumer update; no legacy identity-binding fallback. No native C/C++ or JNI ABI change is required.

Final exact-head validation: [Network conformance passed](https://github.com/CloudburstMC/Network/actions/runs/34713217358) at `b64936b6de814d6c661b889206d8b724b4dc8175`. [Warden Ubuntu CI](https://github.com/teamziax/warden-signalling/actions/runs/34713470103) passed Worker regressions plus Worker/native and real-provider/native benches with clean Warden `9c90c0373f66a7cb58c7735647b6b0f90f451176` and clean Network `b64936b6de814d6c661b889206d8b724b4dc8175`. [Geyser #19](https://github.com/onebeastchris/Geyser/pull/19) depends on publishing this API.
